### PR TITLE
[DCA-43] Set CostCenter tag for all stack resources

### DIFF
--- a/cdk/docker_fargate/docker_fargate_stack.py
+++ b/cdk/docker_fargate/docker_fargate_stack.py
@@ -149,4 +149,5 @@ class DockerFargateStack(Stack):
             # Other metrics to drive scaling are discussed here:
             # https://docs.aws.amazon.com/cdk/api/v1/python/aws_cdk.aws_autoscaling/README.html
 
-        Tags.of(load_balanced_fargate_service).add(COST_CENTER_TAG_NAME, get_cost_center())
+        # Tag all resources in this Stack's scope with a cost center tag
+        Tags.of(scope).add(COST_CENTER_TAG_NAME, get_cost_center())


### PR DESCRIPTION
Apply a cost center tag to all resources in the scope of the stack.