### PR TITLE
[DCA-50] Improve rolling update strategy

### DIFF
--- a/cdk/docker_fargate/docker_fargate_stack.py
+++ b/cdk/docker_fargate/docker_fargate_stack.py
@@ -118,6 +118,7 @@ class DockerFargateStack(Stack):
             cluster=cluster,            # Required
             cpu=256,                    # Default is 256
             desired_count=1,            # Number of copies of the 'task' (i.e. the app') running behind the ALB
+            circuit_breaker=ecs.DeploymentCircuitBreaker(rollback=True), # Enable rollback on deployment failure
             task_image_options=task_image_options,
             memory_limit_mib=1024,      # Default is 512
             public_load_balancer=True,  # Default is False


### PR DESCRIPTION
By default, cdk will create a fargate service using rolling updates without a circuit breaker. Add a fargate circuit breaker with rollback enabled so that a failure to deploy a task will revert to a known good task rather than repeatedly attempt to deploy the current task.

Rolling update docs:
https://docs.aws.amazon.com/AmazonECS/latest/developerguide/deployment-type-ecs.html

Circuit breaker docs:
https://docs.aws.amazon.com/AmazonECS/latest/developerguide/deployment-circuit-breaker.html