### PR TITLE
restored 'synth' tests on PRs; fixed a typo'

### DIFF
--- a/.github/workflows/aws-deploy.yml
+++ b/.github/workflows/aws-deploy.yml
@@ -14,24 +14,6 @@ on:
         type: string
 
 jobs:
-  tests:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v3
-
-      - name: cdk synth
-        uses: youyo/aws-cdk-github-actions@v2
-        with:
-          cdk_subcommand: 'synth'
-          actions_comment: false
-          cdk_args: '--context env=${{ inputs.CONTEXT }} --debug'
-
-      - name: Install dependencies
-        run: pip install -r requirements.txt -r requirements-dev.txt
-
-      - name: Run unit tests
-        run: python -m pytest tests/ -s -v
 
   cdk-deploy:
     needs: tests

--- a/.github/workflows/aws-deploy.yml
+++ b/.github/workflows/aws-deploy.yml
@@ -25,7 +25,7 @@ jobs:
         with:
           cdk_subcommand: 'synth'
           actions_comment: false
-          cdk_args: '--context env=${{ inputs].CONTEXT }} --debug'
+          cdk_args: '--context env=${{ inputs.CONTEXT }} --debug'
 
       - name: Install dependencies
         run: pip install -r requirements.txt -r requirements-dev.txt
@@ -58,5 +58,5 @@ jobs:
 #        uses: youyo/aws-cdk-github-actions@v2
 #        with:
 #          cdk_subcommand: 'deploy'
-#          cdk_args: '--require-approval never --context env=${{ inputs].CONTEXT }} --progress events --debug'
+#          cdk_args: '--require-approval never --context env=${{ inputs.CONTEXT }} --progress events --debug'
 #          actions_comment: false

--- a/.github/workflows/aws-deploy.yml
+++ b/.github/workflows/aws-deploy.yml
@@ -16,7 +16,6 @@ on:
 jobs:
 
   cdk-deploy:
-    needs: tests
     runs-on: ubuntu-latest
     permissions:
       id-token: write

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,6 +19,12 @@ jobs:
       - name: Static Analysis
         uses: pre-commit/action@v3.0.0
 
+      - name: Install dependencies
+        run: pip install -r requirements.txt -r requirements-dev.txt
+
+      - name: Run unit tests
+        run: python -m pytest tests/ -s -v
+
   synth-test-dev:
     needs: tests
     uses: "./.github/workflows/synth-test.yml"
@@ -33,7 +39,7 @@ jobs:
 
   cdk-deploy-dev:
     if: ${{github.ref == 'refs/heads/dev'}}
-    needs: [tests, synth-test-dev, synth-test-prod]
+    needs: [tests, synth-test-dev]
     uses: "./.github/workflows/aws-deploy.yml"
     secrets: inherit
     with:
@@ -42,7 +48,7 @@ jobs:
 
   cdk-deploy-prod:
     if: ${{github.ref == 'refs/heads/prod'}}
-    needs: [tests, synth-test-dev, synth-test-prod]
+    needs: [tests, synth-test-prod]
     uses: "./.github/workflows/aws-deploy.yml"
     secrets: inherit
     with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,9 +19,23 @@ jobs:
       - name: Static Analysis
         uses: pre-commit/action@v3.0.0
 
+  synth-test-dev:
+    needs: tests
+    uses: "./.github/workflows/synth-test.yml"
+    with:
+      CONTEXT: dev
+      REQUIREMENTS_FILE_NAME: requirements-dev.txt
+
+  synth-test-prod:
+    needs: tests
+    uses: "./.github/workflows/synth-test.yml"
+    with:
+      CONTEXT: prod
+      REQUIREMENTS_FILE_NAME: requirements.txt
+
   cdk-deploy-dev:
     if: ${{github.ref == 'refs/heads/dev'}}
-    needs: tests
+    needs: [tests, synth-test-dev, synth-test-prod]
     uses: "./.github/workflows/aws-deploy.yml"
     secrets: inherit
     with:
@@ -30,7 +44,7 @@ jobs:
 
   cdk-deploy-prod:
     if: ${{github.ref == 'refs/heads/prod'}}
-    needs: tests
+    needs: [tests, synth-test-dev, synth-test-prod]
     uses: "./.github/workflows/aws-deploy.yml"
     secrets: inherit
     with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,14 +24,12 @@ jobs:
     uses: "./.github/workflows/synth-test.yml"
     with:
       CONTEXT: dev
-      REQUIREMENTS_FILE_NAME: requirements-dev.txt
 
   synth-test-prod:
     needs: tests
     uses: "./.github/workflows/synth-test.yml"
     with:
       CONTEXT: prod
-      REQUIREMENTS_FILE_NAME: requirements.txt
 
   cdk-deploy-dev:
     if: ${{github.ref == 'refs/heads/dev'}}

--- a/.github/workflows/synth-test.yml
+++ b/.github/workflows/synth-test.yml
@@ -7,9 +7,6 @@ on:
       CONTEXT:
         required: true
         type: string
-      REQUIREMENTS_FILE_NAME:
-        required: true
-        type: string
 
 jobs:
   tests:

--- a/.github/workflows/synth-test.yml
+++ b/.github/workflows/synth-test.yml
@@ -26,7 +26,7 @@ jobs:
           cdk_args: '--context env=${{ inputs.CONTEXT }} --debug'
 
       - name: Install dependencies
-        run: pip install -r ${{ inputs.REQUIREMENTS_FILE_NAME }}
+        run: pip install -r requirements-dev.txt requirements.txt
 
       - name: Run unit tests
         run: python -m pytest tests/ -s -v

--- a/.github/workflows/synth-test.yml
+++ b/.github/workflows/synth-test.yml
@@ -21,9 +21,3 @@ jobs:
           cdk_subcommand: 'synth'
           actions_comment: false
           cdk_args: '--context env=${{ inputs.CONTEXT }} --debug'
-
-      - name: Install dependencies
-        run: pip install -r requirements.txt -r requirements-dev.txt
-
-      - name: Run unit tests
-        run: python -m pytest tests/ -s -v

--- a/.github/workflows/synth-test.yml
+++ b/.github/workflows/synth-test.yml
@@ -23,7 +23,7 @@ jobs:
           cdk_args: '--context env=${{ inputs.CONTEXT }} --debug'
 
       - name: Install dependencies
-        run: pip install -r requirements-dev.txt requirements.txt
+        run: pip install -r requirements.txt -r requirements-dev.txt
 
       - name: Run unit tests
         run: python -m pytest tests/ -s -v

--- a/.github/workflows/synth-test.yml
+++ b/.github/workflows/synth-test.yml
@@ -1,0 +1,32 @@
+
+name: synth-test
+
+on:
+  workflow_call:
+    inputs:
+      CONTEXT:
+        required: true
+        type: string
+      REQUIREMENTS_FILE_NAME:
+        required: true
+        type: string
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: cdk synth
+        uses: youyo/aws-cdk-github-actions@v2
+        with:
+          cdk_subcommand: 'synth'
+          actions_comment: false
+          cdk_args: '--context env=${{ inputs.CONTEXT }} --debug'
+
+      - name: Install dependencies
+        run: pip install -r ${{ inputs.REQUIREMENTS_FILE_NAME }}
+
+      - name: Run unit tests
+        run: python -m pytest tests/ -s -v

--- a/cdk.json
+++ b/cdk.json
@@ -38,9 +38,21 @@
         "CostCenter": "NO PROGRAM / 000000",
         "OwnerEmail": "joe@sagebase.org"
       },
-      "STACK_NAME_PREFIX": "myapp",
+      "STACK_NAME_PREFIX": "myapp-dev",
       "VPC_CIDR": "172.31.0.0/24",
-      "ACM_CERT_ARN": "arn:aws:acm:us-east-1:<ACCOUNT_ID>:certificate/<CERT_ID>"
+      "ACM_CERT_ARN": "arn:aws:acm:us-east-1:<DEV_ACCOUNT_ID>:certificate/<DEV_CERT_ID>"
+    },
+    "prod": {
+      "IMAGE_PATH_AND_TAG": "ghcr.io/sage-bionetworks/myapp:release-1.0",
+      "AWS_DEFAULT_REGION": "us-east-1",
+      "PORT": "3838",
+      "TAGS": {
+        "CostCenter": "NO PROGRAM / 000000",
+        "OwnerEmail": "joe@sagebase.org"
+      },
+      "STACK_NAME_PREFIX": "myapp-prod",
+      "VPC_CIDR": "172.32.0.0/24",
+      "ACM_CERT_ARN": "arn:aws:acm:us-east-1:<PROD_ACCOUNT_ID>:certificate/<PROD_CERT_ID>"
     }
   }
 }


### PR DESCRIPTION
Fixed typo'.

Per @zaro0508 's suggestion:  The workflow now runs the 'synth' test regardless of whether the action is a push/merge or just a PR.  To do this without code replication I factored out the test into a callable workflow and then call it twice (once for 'dev' and once for 'prod') from the 'main' workflow.  This ensures that, for every PR, both the dev and prod configurations are correct.